### PR TITLE
docs: add v0.4.2 Bilibili video link to READMEs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -12,11 +12,11 @@ This monorepo contains the public DSH bundle and its private, editable browser-s
 
 ## Introduction Videos
 
-These videos introduce the original iKanban workflow and its evolution through
-the `v0.3` releases. They predate the current DSH-based package, so installation
-steps and parts of the interface may differ.
+These videos introduce the iKanban workflow and its evolution, including the
+current DSH-based `v0.4.2`. Videos for `v0.3` and earlier predate the current
+package, so their installation steps and parts of the interface may differ.
 
-**Bilibili videos:** [Why I made iKanban](https://www.bilibili.com/video/BV1t9AhztEjX/) · [v0.1](https://www.bilibili.com/video/BV1W3Pgz8ExJ/) · [v0.2](https://www.bilibili.com/video/BV1ZNP1znEn5/) · [v0.2.11 usage guide](https://www.bilibili.com/video/BV1Y9wMzKE2b/) · [v0.3](https://www.bilibili.com/video/BV1n9QEBSEch/) · [v0.3.14](https://www.bilibili.com/video/BV1zy3F6aEb2/)
+**Bilibili videos:** [Why I made iKanban](https://www.bilibili.com/video/BV1t9AhztEjX/) · [v0.1](https://www.bilibili.com/video/BV1W3Pgz8ExJ/) · [v0.2](https://www.bilibili.com/video/BV1ZNP1znEn5/) · [v0.2.11 usage guide](https://www.bilibili.com/video/BV1Y9wMzKE2b/) · [v0.3](https://www.bilibili.com/video/BV1n9QEBSEch/) · [v0.3.14](https://www.bilibili.com/video/BV1zy3F6aEb2/) · [v0.4.2](https://www.bilibili.com/video/BV156b26eEbn/)
 
 ## Packages
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ iKanban 是一个面向键盘操作、基于 [DeepSeek Harness](https://github.c
 
 ## 介绍视频
 
-以下视频介绍了 iKanban 最初的工作流及其贯穿 `v0.3` 系列版本的演进。这些视频早于当前基于 DSH 的软件包，因此安装步骤和部分界面可能有所不同。
+以下视频介绍了 iKanban 的工作流及其演进，包括当前基于 DSH 的 `v0.4.2`。`v0.3` 及更早的视频早于当前软件包，因此其中的安装步骤和部分界面可能有所不同。
 
-**Bilibili 视频：** [为什么做它](https://www.bilibili.com/video/BV1t9AhztEjX/) · [v0.1](https://www.bilibili.com/video/BV1W3Pgz8ExJ/) · [v0.2](https://www.bilibili.com/video/BV1ZNP1znEn5/) · [v0.2.11 如何使用](https://www.bilibili.com/video/BV1Y9wMzKE2b/) · [v0.3](https://www.bilibili.com/video/BV1n9QEBSEch/) · [v0.3.14](https://www.bilibili.com/video/BV1zy3F6aEb2/)
+**Bilibili 视频：** [为什么做它](https://www.bilibili.com/video/BV1t9AhztEjX/) · [v0.1](https://www.bilibili.com/video/BV1W3Pgz8ExJ/) · [v0.2](https://www.bilibili.com/video/BV1ZNP1znEn5/) · [v0.2.11 如何使用](https://www.bilibili.com/video/BV1Y9wMzKE2b/) · [v0.3](https://www.bilibili.com/video/BV1n9QEBSEch/) · [v0.3.14](https://www.bilibili.com/video/BV1zy3F6aEb2/) · [v0.4.2](https://www.bilibili.com/video/BV156b26eEbn/)
 
 ## 软件包
 


### PR DESCRIPTION
### Motivation

- Surface the `v0.4.2` Bilibili demo video in the project documentation and clarify which older videos predate the current DSH-based package.

### Description

- Added the `v0.4.2` Bilibili video link (`BV156b26eEbn`) and adjusted the introduction text in `README.md` to reference the current DSH-based `v0.4.2`.
- Kept the English README (`README.en.md`) synchronized with the same `v0.4.2` video link and updated wording to reflect the current package.

### Testing

- Ran `git diff --check` which completed without errors.
- Verified repository status with `git status --short` and committed the changes as `docs: add v0.4.2 Bilibili video` (commit `b9491d1`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a811caac49c832796d38f8fe2082356)